### PR TITLE
Correct properties_set for successful compilation

### DIFF
--- a/init/init_s3ve3g.cpp
+++ b/init/init_s3ve3g.cpp
@@ -61,7 +61,8 @@ void init_msm_properties(unsigned long msm_id, unsigned long msm_ver, char *boar
         property_set("ro.product.model", "GT-I9301I");
         property_set("ro.product.device", "s3ve3g");
         property_set("ro.telephony.ril_class", "SamsungMSM8226RIL");
-        gsm_properties();
+        property_set("telephony.lteOnGsmDevice", "0");
+        property_set("ro.telephony.default_network", "0");
     } else if (strstr(bootloader, "I9301Q")) {
         /* s3ve3gjv */
         property_set("ro.build.fingerprint", "samsung/s3ve3gjv/s3ve3g:4.4.2/KOT49H/I9301QXXUANH1:user/release-keys");
@@ -69,7 +70,8 @@ void init_msm_properties(unsigned long msm_id, unsigned long msm_ver, char *boar
         property_set("ro.product.model", "GT-I9301Q");
         property_set("ro.product.device", "s3ve3gjv");
         property_set("ro.telephony.ril_class", "SamsungMSM8226RIL");
-        gsm_properties();
+        property_set("telephony.lteOnGsmDevice", "0");
+        property_set("ro.telephony.default_network", "0");
     } else if (strstr(bootloader, "I9300I")) {
         /* s3ve3gds */
         property_set("ro.build.fingerprint", "samsung/s3ve3gdsxx/s3ve3gds:4.4.4/KTU84P/I9300IXWUBNJ1:user/release-keys");
@@ -80,16 +82,11 @@ void init_msm_properties(unsigned long msm_id, unsigned long msm_ver, char *boar
         property_set("ro.multisim.simslotcount", "2");
         property_set("persist.radio.multisim.config", "dsds");
         property_set("ro.telephony.ril_class", "SamsungMSM8226DSRIL");
-        gsm_properties();
+        property_set("telephony.lteOnGsmDevice", "0");
+        property_set("ro.telephony.default_network", "0");
     }
 
     property_get("ro.product.device", device);
     strlcpy(devicename, device, sizeof(devicename));
     INFO("Found bootloader id %s setting build properties for %s device\n", bootloader, devicename);
-}
-
-void gsm_properties()
-{
-    property_set("telephony.lteOnGsmDevice", "0");
-    property_set("ro.telephony.default_network", "0");
 }


### PR DESCRIPTION
device/qcom/common/init/../../../../device/samsung/s3ve3g/init/init_s3ve3g.cpp: In function 'void init_msm_properties(long unsigned int, long unsigned int, char*)':
device/qcom/common/init/../../../../device/samsung/s3ve3g/init/init_s3ve3g.cpp:64:24: error: 'gsm_properties' was not declared in this scope
         gsm_properties();
                        ^
device/qcom/common/init/../../../../device/samsung/s3ve3g/init/init_s3ve3g.cpp:72:24: error: 'gsm_properties' was not declared in this scope
         gsm_properties();
                        ^
device/qcom/common/init/../../../../device/samsung/s3ve3g/init/init_s3ve3g.cpp:83:24: error: 'gsm_properties' was not declared in this scope
         gsm_properties();
                        ^
